### PR TITLE
Y axis label count change fix

### DIFF
--- a/MPChartLib/build.gradle
+++ b/MPChartLib/build.gradle
@@ -16,7 +16,7 @@ android {
         minSdkVersion 9
         targetSdkVersion 27
         versionCode 3
-        version '3.0.3.5'
+        version '3.0.3.6'
         archivesBaseName = "MPAndroidChart"
     }
     buildTypes {

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
@@ -187,7 +187,7 @@ public abstract class AxisRenderer extends Renderer {
             interval = (float) range / (float) (labelCount - 1);
             mAxis.mEntryCount = labelCount;
 
-            if (mAxis.mEntries.length < labelCount) {
+            if (mAxis.mEntries.length != labelCount) {
                 // Ensure stops contains at least numStops elements.
                 mAxis.mEntries = new float[labelCount];
             }
@@ -222,7 +222,7 @@ public abstract class AxisRenderer extends Renderer {
 
             mAxis.mEntryCount = n;
 
-            if (mAxis.mEntries.length < n) {
+            if (mAxis.mEntries.length != n) {
                 // Ensure stops contains at least numStops elements.
                 mAxis.mEntries = new float[n];
             }
@@ -245,7 +245,7 @@ public abstract class AxisRenderer extends Renderer {
 
         if (mAxis.isCenterAxisLabelsEnabled()) {
 
-            if (mAxis.mCenteredEntries.length < n) {
+            if (mAxis.mCenteredEntries.length != n) {
                 mAxis.mCenteredEntries = new float[n];
             }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRendererRadarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRendererRadarChart.java
@@ -66,7 +66,7 @@ public class YAxisRendererRadarChart extends YAxisRenderer {
             float step = (float) range / (float) (labelCount - 1);
             mAxis.mEntryCount = labelCount;
 
-            if (mAxis.mEntries.length < labelCount) {
+            if (mAxis.mEntries.length != labelCount) {
                 // Ensure stops contains at least numStops elements.
                 mAxis.mEntries = new float[labelCount];
             }
@@ -103,7 +103,7 @@ public class YAxisRendererRadarChart extends YAxisRenderer {
 
             mAxis.mEntryCount = n;
 
-            if (mAxis.mEntries.length < n) {
+            if (mAxis.mEntries.length != n) {
                 // Ensure stops contains at least numStops elements.
                 mAxis.mEntries = new float[n];
             }
@@ -126,7 +126,7 @@ public class YAxisRendererRadarChart extends YAxisRenderer {
 
         if (centeringEnabled) {
 
-            if (mAxis.mCenteredEntries.length < n) {
+            if (mAxis.mCenteredEntries.length != n) {
                 mAxis.mCenteredEntries = new float[n];
             }
 


### PR DESCRIPTION
Reinitializing the chart with data having lower y xis label count then before now correctly reports total size in the label renderer callback.